### PR TITLE
"Preset list of variants" example

### DIFF
--- a/example.html
+++ b/example.html
@@ -2,38 +2,102 @@
 <html lang='en'>
 <head>
   <meta charset='utf-8'>
-  <title>Test raremetal.js</title>
-
-  <!--<script src="../node_modules//babel-polyfill/dist/polyfill.min.js"></script>-->
-
-  <!-- Load the built library -->
-  <script src='dist/raremetal.js'></script>
-
-  <!-- Try running a few burden tests -->
-  <script>
-    console.log("Starting burden tests...");
-    async function _example(filename) {
-      // Load example JSON of portal response from requesting covariance in a region
-      filename = filename || "test/integration/scorecov.json";
-      const response = await fetch(filename, { credentials: 'include' });
-      const json = await response.json();
-      const [ groups, variants ] = raremetal.helpers.parsePortalJSON(json);
-      const runner = new raremetal.helpers.PortalTestRunner(groups, variants, ['burden', 'skat', 'vt']);
-      return runner;
+  <title>Example usage of raremetal.js</title>
+  <style>
+    body {
+      font-family: sans-serif;
     }
-
-
-
-    let promise = _example();
-    let runner;
-    promise.then(res => {
-        runner = res;
-        console.log(runner.run());
-    });
-  </script>
-
+  </style>
 </head>
 <body>
+<h1>Sample aggregation test calculations</h1>
+<h2>Results</h2>
+<textarea id="results-display" rows=20 style="width:100%;">Performing sample calculation...</textarea>
+
+<script src='dist/raremetal.js'></script>
+
+<script>
+  // Tell the UM LD server to run burden tests based on one particular dataset and a specified list of variants
+  const sample_mask_payload = {
+    "chrom": "22",
+    "start": 50276998,
+    "stop": 50357719,
+    "genotypeDataset": 1,
+    "phenotypeDataset": 1,
+    "phenotype": "ldl",
+    "samples": "ALL",
+    "genomeBuild": "GRCh37",
+    "maskDefinitions": [
+      {
+        "id": 10,
+        "name": "On-the-fly mask",
+        "description": "Mask created on the fly, potentially by using a browser UI",
+        "genome_build": "GRCh37",
+        "group_type": "GENE",
+        "identifier_type": "ENSEMBL",
+        "groups": {
+          "CRELD2": [
+            "22:50312454_C/T",
+            "22:50313452_C/T",
+            "22:50313465_C/A",
+            "22:50315537_A/G",
+            "22:50315971_C/G",
+            "22:50316015_C/T",
+            "22:50316301_A/G",
+            "22:50316902_G/A",
+            "22:50316906_C/T",
+            "22:50317418_C/T",
+            "22:50318061_G/C",
+            "22:50318402_C/T",
+            "22:50318757_C/T",
+            "22:50319373_C/T",
+            "22:50319968_G/A",
+            "22:50320921_G/A"
+          ]
+        }
+      }
+    ]
+  };
+
+  /**
+   * Demonstrate the actual process of running one or more burden tests, by fetching covariance data for a single
+   *  pre-defined list of variants
+   * @return {Promise<Response | never>}
+   */
+  function _example(url, covariance_request_spec) {
+    return fetch(url, { // Tell the server to calculate covariance for specified groups
+      method: 'POST',
+      body: JSON.stringify(covariance_request_spec),
+      headers: {
+        'Content-Type': 'application/json',
+      }
+    }).then(resp => {
+      if (resp.ok) {
+        return resp.json();
+      } else {
+        throw new Error('Request failed');
+      }
+    }).then(json => { // Use the returned covariance data to run aggregation tests and return results (note that runner.run() returns a Promise)
+      const [groups, variants] = raremetal.helpers.parsePortalJSON(json);
+      const runner = new raremetal.helpers.PortalTestRunner(groups, variants, [ // One or more test names can be specified!
+        // 'burden',
+        'skat',
+        // 'vt'
+      ]);
+      return runner.run();
+    });
+  }
+
+  // When the page loads, get the data and display the results
+  const results = document.getElementById('results-display');
+  _example('https://portaldev.sph.umich.edu/raremetal/v1/aggregation/covariance', sample_mask_payload).then(res => {
+    console.log(`Ran ${res.length} test(s)`);
+    console.log(res);
+    results.value = JSON.stringify(res, null, 4);
+  }).catch(e => {
+    results.value = 'Calculations failed; see JS console for details.'
+  });
+</script>
 
 </body>
 </html>

--- a/src/app/helpers.js
+++ b/src/app/helpers.js
@@ -203,8 +203,22 @@ class PortalGroupHelper {
   }
 }
 
-// Helper method that coordinates multiple tests on a series of masks
+/**
+ * Run one or more burden tests. This will operate in sequence: all specified tests on all specified masks
+ *
+ * The actual call signature of a burden test is pretty low-level. In addition to running the list of tests,
+ *  this helper also restructures human-friendly mask and variant representations into a shape that works directly
+ *  with the calculation.
+ */
 class PortalTestRunner {
+  /**
+   * Create a test runner object, using group and variant data of the form provided by `parsePortalJSON`. Generally,
+   *  this helper is a convenience wrapper based on the raremetal.js API format spec, and hence it expects
+   *  variant and group definitions to follow that spec.
+   * @param groups PortalGroupHelper
+   * @param variants PortalVariantsHelper
+   * @param test_names {String[]|_AggregationTest[]}
+   */
   constructor(groups, variants, test_names = []) {
     this.groups = groups;
     this.variants = variants;
@@ -213,9 +227,13 @@ class PortalTestRunner {
     test_names.forEach(name => this.addTest(name));
   }
 
+  /**
+   *
+   * @param test {String|_AggregationTest}
+   * @return {_AggregationTest}
+   */
   addTest(test) {
     // Add a new test by name, or directly from an instance
-    // TODO Find a way to do this without using the registry
     if (typeof test === 'string') {
       let type = AGGREGATION_TESTS[test];
       if (!type) {
@@ -225,8 +243,6 @@ class PortalTestRunner {
     } else if (!(test instanceof _AggregationTest)) {
       throw new Error('Must specify test as name or instance');
     }
-
-
     this._tests.push(test);
     return test;
   }


### PR DESCRIPTION
# Purpose 
A quick revamp of `example.html`, to better reflect a sample usage scenario for the T2D portal.

- Use a preset list of variants (rather than mask name)
- Run a single test
- Works with LDserver-formatted covariance JSON

I've also added a few quick docstrings where they were previously lacking.

![Screen Shot 2019-07-18 at 5 54 57 PM](https://user-images.githubusercontent.com/2957073/61494808-31a2ad00-a985-11e9-8805-7321dfe9c77d.png)
